### PR TITLE
Tag Docker image with GitHub SHA (M2 T1a)

### DIFF
--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -28,4 +28,6 @@ jobs:
         with:
           context: .
           push: true
-          tags: jacoblum22/dsci-310-group-03:latest
+          tags: |
+            jacoblum22/dsci-310-group-03:latest
+            jacoblum22/dsci-310-group-03:${{ github.sha }}


### PR DESCRIPTION
## M2 T1a — Docker SHA image tagging

Adds a second tag to the DockerHub push so every build is versioned with the commit SHA:

```
jacoblum22/dsci-310-group-03:latest
jacoblum22/dsci-310-group-03:<github-sha>
```

### Change
One-line edit to `.github/workflows/publish_docker_image.yml` — the `tags` field now accepts two entries on separate lines using the YAML multiline string syntax.

### How to verify
After merging, trigger the workflow (push a Dockerfile change or run it manually via `workflow_dispatch`). Check [DockerHub](https://hub.docker.com/r/jacoblum22/dsci-310-group-03/tags) and confirm both `latest` and a 40-character SHA tag appear.

Closes #11