### PR TITLE
fix: add Quarto to Docker image for report rendering

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,3 +4,12 @@ COPY environment.yml .
 
 RUN conda env update --name base --file environment.yml && \
     conda clean --all -y
+
+# Install Quarto for report rendering
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends curl gdebi-core && \
+    curl -LO https://github.com/quarto-dev/quarto-cli/releases/download/v1.6.43/quarto-1.6.43-linux-amd64.deb && \
+    gdebi --non-interactive quarto-1.6.43-linux-amd64.deb && \
+    rm quarto-1.6.43-linux-amd64.deb && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+USER ${NB_UID}


### PR DESCRIPTION
## Problem
`make all` fails inside the Docker container because Quarto is not installed. The Makefile's final target runs `quarto render` to produce the HTML report, but the base `scipy-notebook` image doesn't include Quarto.

## Fix
Install Quarto 1.6.43 via the official `.deb` package (pinned version per M1 requirements). Uses `gdebi` for dependency resolution instead of conda, which is significantly faster.

## Testing
Ran `make clean && make all` inside the container — all 4 scripts + Quarto render completed successfully. All expected output files produced.