### PR TITLE
fix: update Docker image digest to include Quarto

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This project investigates whether the quality of wine can be predicted from its 
 2. Pull the image from DockerHub:
 
    ```bash
-   docker pull jacoblum22/dsci-310-group-03@sha256:ff021892fac1b14f2dfa9fe20b392ba29e1a76dce17624354533be63f92e9c8e
+   docker pull jacoblum22/dsci-310-group-03@sha256:08be05f3f5feb5ab41a2f0a77031df070539edeb69df7aeb9f45d8ee6a6d60fa
    ```
 
 3. Launch the container with Docker Compose:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   analysis:
-    image: jacoblum22/dsci-310-group-03@sha256:ff021892fac1b14f2dfa9fe20b392ba29e1a76dce17624354533be63f92e9c8e
+    image: jacoblum22/dsci-310-group-03@sha256:08be05f3f5feb5ab41a2f0a77031df070539edeb69df7aeb9f45d8ee6a6d60fa
     ports:
       - "8888:8888"
     volumes:


### PR DESCRIPTION
The `docker-compose.yml` and README referenced image digest `sha256:ff021892...` which was built **before** Quarto was added to the Dockerfile (PR #26). This meant anyone following the README instructions would get an image without Quarto, causing `make all` to fail at the `quarto render` step.\n\nUpdated to `sha256:08be05f3...` which is the image built by GitHub Actions after PR #26 merged (includes Quarto 1.6.43).