### PR TITLE
M3 Task 1: Abstract run_knn_grid_search() to src/model_utils.py

### DIFF
--- a/scripts/train_model.py
+++ b/scripts/train_model.py
@@ -2,11 +2,8 @@ import click
 import pandas as pd
 import matplotlib.pyplot as plt
 import os
-from sklearn.model_selection import GridSearchCV
-from sklearn.preprocessing import StandardScaler
-from sklearn.neighbors import KNeighborsRegressor
-from sklearn.pipeline import make_pipeline
 from src.data_utils import extract_features_and_target
+from src.model_utils import run_knn_grid_search
 
 
 @click.command()
@@ -39,19 +36,13 @@ def main(train_path, test_path, output_dir):
     X_train, y_train = extract_features_and_target(train_df, "quality")
     X_test, y_test = extract_features_and_target(test_df, "quality")
 
-    # Build pipeline
-    pipe = make_pipeline(StandardScaler(), KNeighborsRegressor())
-
-    # Grid search over K = 1..29 with cross-validation
-    k_values = list(range(1, 30))
-    param_grid = {"kneighborsregressor__n_neighbors": k_values}
-    grid = GridSearchCV(pipe, param_grid, n_jobs=-1, return_train_score=True)
-    grid.fit(X_train, y_train)
-
-    best_k = grid.best_params_["kneighborsregressor__n_neighbors"]
-    best_cv_score = grid.best_score_
-    best_model = grid.best_estimator_
-    best_train_score = best_model.score(X_train, y_train)
+    # Run grid search
+    results = run_knn_grid_search(X_train, y_train)
+    best_k = results["best_k"]
+    best_cv_score = results["best_cv_score"]
+    best_model = results["best_model"]
+    best_train_score = results["best_train_score"]
+    cv_results = results["cv_results_df"]
     test_score = best_model.score(X_test, y_test)
 
     print(f"Best K: {best_k}")
@@ -60,15 +51,6 @@ def main(train_path, test_path, output_dir):
     print(f"Test R²:  {test_score:.5f}")
 
     # Save CV results table
-    cv_results = pd.DataFrame(grid.cv_results_)[
-        [
-            "params",
-            "mean_test_score",
-            "std_test_score",
-            "mean_train_score",
-            "std_train_score",
-        ]
-    ]
     cv_results.to_csv(os.path.join(output_dir, "cv_results.csv"), index=False)
     print(f"CV results table saved to {output_dir}/cv_results.csv")
 
@@ -83,9 +65,9 @@ def main(train_path, test_path, output_dir):
     print(f"Model scores table saved to {output_dir}/model_scores.csv")
 
     # Save CV score vs K figure
-    cv_df = pd.DataFrame(grid.cv_results_)
+    k_values = list(range(1, 30))
     plt.figure(figsize=(10, 5))
-    plt.plot(k_values, cv_df["mean_test_score"])
+    plt.plot(k_values, cv_results["mean_test_score"])
     plt.scatter(best_k, best_cv_score, color="red", zorder=5, label=f"Best K={best_k}")
     plt.xlabel("Number of Neighbors (K)")
     plt.ylabel("Mean CV Score (R²)")

--- a/src/model_utils.py
+++ b/src/model_utils.py
@@ -1,0 +1,54 @@
+import pandas as pd
+from sklearn.model_selection import GridSearchCV
+from sklearn.preprocessing import StandardScaler
+from sklearn.neighbors import KNeighborsRegressor
+from sklearn.pipeline import make_pipeline
+
+
+def run_knn_grid_search(X_train, y_train, k_values=None):
+    """Run KNN grid search with cross-validation and return results.
+
+    Parameters
+    ----------
+    X_train : pd.DataFrame
+        Training features.
+    y_train : pd.Series
+        Training target.
+    k_values : list of int, optional
+        Values of K to search over. Defaults to range(1, 30).
+
+    Returns
+    -------
+    dict
+        Keys: best_k, best_cv_score, best_model, best_train_score, cv_results_df
+    """
+    if k_values is None:
+        k_values = list(range(1, 30))
+
+    pipe = make_pipeline(StandardScaler(), KNeighborsRegressor())
+    param_grid = {"kneighborsregressor__n_neighbors": k_values}
+    grid = GridSearchCV(pipe, param_grid, n_jobs=-1, return_train_score=True)
+    grid.fit(X_train, y_train)
+
+    best_k = grid.best_params_["kneighborsregressor__n_neighbors"]
+    best_cv_score = float(grid.best_score_)
+    best_model = grid.best_estimator_
+    best_train_score = float(best_model.score(X_train, y_train))
+
+    cv_results_df = pd.DataFrame(grid.cv_results_)[
+        [
+            "params",
+            "mean_test_score",
+            "std_test_score",
+            "mean_train_score",
+            "std_train_score",
+        ]
+    ]
+
+    return {
+        "best_k": best_k,
+        "best_cv_score": best_cv_score,
+        "best_model": best_model,
+        "best_train_score": best_train_score,
+        "cv_results_df": cv_results_df,
+    }

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -1,0 +1,66 @@
+import pytest
+import pandas as pd
+import numpy as np
+from sklearn.pipeline import Pipeline
+from src.model_utils import run_knn_grid_search
+
+
+@pytest.fixture
+def synthetic_regression_data():
+    """Create a small synthetic dataset for KNN regression testing."""
+    rng = np.random.RandomState(42)
+    X = pd.DataFrame({"f1": rng.rand(50), "f2": rng.rand(50), "f3": rng.rand(50)})
+    y = pd.Series(X["f1"] * 3 + X["f2"] * 2 + rng.normal(0, 0.1, 50), name="target")
+    return X, y
+
+
+class TestRunKnnGridSearch:
+    """Tests for run_knn_grid_search."""
+
+    def test_returns_dict_with_expected_keys(self, synthetic_regression_data):
+        X, y = synthetic_regression_data
+        result = run_knn_grid_search(X, y, k_values=[1, 3, 5])
+        expected_keys = {"best_k", "best_cv_score", "best_model", "best_train_score", "cv_results_df"}
+        assert set(result.keys()) == expected_keys
+
+    def test_best_k_is_int_in_range(self, synthetic_regression_data):
+        X, y = synthetic_regression_data
+        k_vals = [2, 4, 6]
+        result = run_knn_grid_search(X, y, k_values=k_vals)
+        assert isinstance(result["best_k"], (int, np.integer))
+        assert result["best_k"] in k_vals
+
+    def test_scores_are_floats(self, synthetic_regression_data):
+        X, y = synthetic_regression_data
+        result = run_knn_grid_search(X, y, k_values=[3, 5])
+        assert isinstance(result["best_cv_score"], float)
+        assert isinstance(result["best_train_score"], float)
+
+    def test_scores_in_reasonable_range(self, synthetic_regression_data):
+        X, y = synthetic_regression_data
+        result = run_knn_grid_search(X, y, k_values=[3, 5])
+        assert -1.0 <= result["best_cv_score"] <= 1.0
+        assert -1.0 <= result["best_train_score"] <= 1.0
+
+    def test_best_model_is_pipeline(self, synthetic_regression_data):
+        X, y = synthetic_regression_data
+        result = run_knn_grid_search(X, y, k_values=[3])
+        assert isinstance(result["best_model"], Pipeline)
+
+    def test_cv_results_df_is_dataframe(self, synthetic_regression_data):
+        X, y = synthetic_regression_data
+        result = run_knn_grid_search(X, y, k_values=[1, 3, 5])
+        assert isinstance(result["cv_results_df"], pd.DataFrame)
+        assert len(result["cv_results_df"]) == 3
+
+    def test_default_k_values(self, synthetic_regression_data):
+        X, y = synthetic_regression_data
+        result = run_knn_grid_search(X, y)
+        assert len(result["cv_results_df"]) == 29
+        assert result["best_k"] in range(1, 30)
+
+    def test_raises_on_empty_data(self):
+        X = pd.DataFrame({"f1": [], "f2": []})
+        y = pd.Series([], dtype=float)
+        with pytest.raises(ValueError):
+            run_knn_grid_search(X, y, k_values=[1, 3])


### PR DESCRIPTION
## Summary
Extracts the KNN grid search logic from `scripts/train_model.py` into a reusable function `run_knn_grid_search()` in `src/model_utils.py`, with 8 pytest tests.

## Changes
- **`src/model_utils.py`** - New `run_knn_grid_search(X_train, y_train, k_values=None)` function that:
  - Builds a StandardScaler -> KNeighborsRegressor pipeline
  - Runs GridSearchCV over K=1-29 (configurable)
  - Returns dict with `best_k`, `best_cv_score`, `best_model`, `best_train_score`, `cv_results_df`
- **`tests/test_model_utils.py`** - 8 tests: expected keys, types, score ranges, default k values, empty data error
- **`scripts/train_model.py`** - Replaced inline sklearn imports and grid search code with `from src.model_utils import run_knn_grid_search`

## Tests
All 12 tests pass (4 from T2 + 8 from T1):

- tests/test_data_utils.py - 4 passed
- tests/test_model_utils.py - 8 passed

Closes #29