### PR TITLE
M3 Task 4: Abstract plot_correlation_heatmap() to src/plot_utils.py

### DIFF
--- a/scripts/eda.py
+++ b/scripts/eda.py
@@ -3,6 +3,7 @@ import pandas as pd
 import matplotlib.pyplot as plt
 import seaborn as sns
 import os
+from src.plot_utils import plot_correlation_heatmap
 
 
 @click.command()
@@ -43,13 +44,7 @@ def main(input_path, output_dir):
     print(f"Quality distribution plot saved to {output_dir}/quality_distribution.png")
 
     # Figure 2: Correlation Heatmap
-    plt.figure(figsize=(8, 7))
-    sns.heatmap(wine_df.corr(numeric_only=True), annot=True, fmt=".2f", cmap="coolwarm")
-    plt.title("Correlation Heatmap of Wine Features")
-    plt.savefig(
-        os.path.join(output_dir, "correlation_heatmap.png"), bbox_inches="tight"
-    )
-    plt.close()
+    plot_correlation_heatmap(wine_df, os.path.join(output_dir, "correlation_heatmap.png"))
     print(f"Correlation heatmap saved to {output_dir}/correlation_heatmap.png")
 
     # Figure 3: Alcohol Content by Wine Quality

--- a/src/plot_utils.py
+++ b/src/plot_utils.py
@@ -1,0 +1,44 @@
+import pandas as pd
+import matplotlib.pyplot as plt
+import seaborn as sns
+import os
+
+def plot_correlation_heatmap(df, output_path, figsize=(8,7)):
+    """
+    Plot a correlation heatmap and save it as a PNG. 
+    
+    Parameters:
+    ---
+        df: pd.DataFrame
+            The input DataFrame containing the data to analyze with numeric values
+        output_path: str
+            File path where the PNG will be saved
+        figsize: tuple, optional
+            Figure size as (width, height)
+    Returns:
+    ---
+    None (saves PNG file)
+    
+    Example:
+    --- 
+    >>> df = pd.read_csv('wine_predictions')
+    >>> filepath = "../results/figures"
+    >>> plot_correlation_heatmap(df, filepath)
+    
+    
+    """
+    
+    numeric_df = df.select_dtypes(include="number")
+    
+    if numeric_df.empty: # check if dataframe contains at least one numeric column
+        raise ValueError("DataFrame must contain at least one numeric column.")
+    
+    # creates parent directory for output file if it does not already exist
+    os.makedirs(os.path.dirname(os.path.abspath(output_path)), exist_ok=True) 
+    
+    fig, ax = plt.subplots(figsize=figsize) #sets fig size
+    sns.heatmap(numeric_df.corr(), annot=True, fmt=".2f", cmap="coolwarm", ax=ax) 
+    plt.title("Correlation Heatmap of Wine Features")
+    fig.tight_layout()
+    fig.savefig(output_path)
+    plt.close(fig)

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -1,0 +1,63 @@
+import os
+import pytest
+import pandas as pd
+import matplotlib.pyplot as plt
+
+from src.plot_utils import plot_correlation_heatmap
+# `plot_correlation_heatmap` should return a PNG of a heatmap figure
+
+# to run tests
+# python -m pytest tests/test_plot_utils.py
+
+
+@pytest.fixture
+def numeric_df():
+    """Create a small synthetic dataset for heatmap correlation testing"""
+    return pd.DataFrame({
+        "alcohol": [8.0, 9.0, 10.0, 11.0],
+        "pH": [3.1, 3.2, 3.3, 3.4],
+        "sulphates": [0.5, 0.6, 0.7, 0.8],
+    })
+
+class TestRunPlotCorrelationHeatmap:
+    """tests for plot_correlation_heatmap"""
+    #test if output PNG file is created at the specified path
+    def test_output_file_is_created_path(self, numeric_df, tmp_path):
+        output = str(tmp_path / "correlation_heatmap.png")
+        plot_correlation_heatmap(numeric_df, output)
+        assert os.path.exists(output)
+
+    #test if output file is a valid PNG
+    def test_output_is_valid_png(self, numeric_df, tmp_path):
+        output = str(tmp_path / "correlation_heatmap.png")
+        plot_correlation_heatmap(numeric_df, output)
+        with open(output, "rb") as f:
+            magic = f.read(4)
+        assert magic == b"\x89PNG"
+        
+
+    #test if works with numeric only dataframe
+    def test_works_with_numeric_only_dataframe(self, numeric_df, tmp_path):
+        output = str(tmp_path / "correlation_heatmap.png")
+        plot_correlation_heatmap(numeric_df, output)  # should not raise
+
+    #test if it raises error with no numeric columns
+    def test_raise_with_no_numeric_columns(self, tmp_path):
+        df = pd.DataFrame({"type": ["red", "white"], "region": ["napa", "sonoma"]})
+        output = str(tmp_path / "correlation_heatmap.png")
+        with pytest.raises(ValueError, match="numeric"):
+            plot_correlation_heatmap(df, output)
+
+    #test custom figsize is respected
+    def test_custom_figsize_is_respected(self, numeric_df, tmp_path):
+        output = str(tmp_path / "correlation_heatmap.png")
+        plot_correlation_heatmap(numeric_df, output, figsize=(10, 9))
+        img = plt.imread(output)
+        assert img.shape[1] == 1000  # width: 10in * 100dpi
+        assert img.shape[0] == 900   # height: 9in * 100dpi
+
+    #creates parent directories if they do not exist
+    def test_creates_parent_directories(self, numeric_df, tmp_path):
+        output = str(tmp_path / "nested" / "dirs" / "correlation_heatmap.png")
+        plot_correlation_heatmap(numeric_df, output)
+        assert os.path.exists(output)


### PR DESCRIPTION
## Summary
Extracts the correlation heatmap logic from `scripts/eda.py` into a reusable function `plot_correlation_heatmap()` in `src/plot_utils.py`, with 6 pytest tests.

## Changes
- **`src/plot_utils.py`** - New `plot_correlation_heatmap(df, output_path, figsize=(8,7))` function that:
  - Selects numeric columns from the DataFrame
  - Validates at least one numeric column exists
  - Creates parent directories for the output path
  - Generates a seaborn correlation heatmap and saves as PNG
- **`tests/test_plot_utils.py`** - 6 tests: file creation, valid PNG, numeric-only df, no-numeric error, custom figsize, parent directory creation
- **`scripts/eda.py`** - Replaced inline heatmap code with `from src.plot_utils import plot_correlation_heatmap`

## Tests
All 10 tests pass (4 from T2 + 6 from T4):

- tests/test_data_utils.py - 4 passed
- tests/test_plot_utils.py - 6 passed

Closes #32