### PR TITLE
fix: revert CI to build+push only (branch protection blocks direct push)

### DIFF
--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -12,14 +12,10 @@ on:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -28,7 +24,6 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push Docker image
-        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -37,15 +32,4 @@ jobs:
             jacoblum22/dsci-310-group-03:latest
             jacoblum22/dsci-310-group-03:${{ github.sha }}
 
-      - name: Update docker-compose.yml with new digest
-        run: |
-          NEW_DIGEST="${{ steps.build.outputs.digest }}"
-          sed -i "s|jacoblum22/dsci-310-group-03@sha256:[a-f0-9]*|jacoblum22/dsci-310-group-03@${NEW_DIGEST}|" docker-compose.yml
-
-      - name: Commit updated digest
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add docker-compose.yml
-          git diff --cached --quiet || git commit -m "ci: update Docker image digest to ${GITHUB_SHA::7}"
           git push


### PR DESCRIPTION
Reverts the CI workflow to its original build+push behavior. The auto-commit of the Docker digest failed because branch protection requires changes via PR. The CI will still build and push new images to Docker Hub; the digest in docker-compose.yml is updated manually when needed.