### PR TITLE
fix: remove workflow YAML error and missing styles.css reference

### DIFF
--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -31,5 +31,3 @@ jobs:
           tags: |
             jacoblum22/dsci-310-group-03:latest
             jacoblum22/dsci-310-group-03:${{ github.sha }}
-
-          git push

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -7,7 +7,6 @@ bibliography: notebooks/references.bib
   
 format:
   html:
-    css: styles.css
     html-math-method: katex
   pdf:
     documentclass: report


### PR DESCRIPTION
Fixes two issues:

1. **Workflow YAML syntax error** — Removed a stray `git push` on line 35 of `.github/workflows/publish_docker_image.yml` that was causing "Invalid workflow file" errors.

2. **Missing `styles.css` reference** — Removed `css: styles.css` from `_quarto.yml` since the file never existed. Quarto now uses default styling (verified renders correctly).