### PR TITLE
Add 11 textbook data validation checks to data and preprocess scripts

### DIFF
--- a/scripts/download_data.py
+++ b/scripts/download_data.py
@@ -3,7 +3,6 @@ import pandas as pd
 import os
 from ucimlrepo import fetch_ucirepo
 
-
 @click.command()
 @click.option(
     "--output-path",
@@ -17,6 +16,14 @@ def main(output_path):
 
     wine_df = pd.concat([wine_quality.data.features, wine_quality.data.targets], axis=1)
 
+    # ------------------------------------------
+    # DATA VALIDATION CHECK 1
+    # ------------------------------------------
+    # Check 1: Correct data file format (ensures it's a non-empty df before saving)
+    assert isinstance(wine_df, pd.DataFrame), "Validation Hard Fail: Downloaded data is not a DataFrame."
+    assert not wine_df.empty, "Validation Hard Fail: Downloaded dataset is completely empty."
+    # ------------------------------------------
+
     output_dir = os.path.dirname(output_path)
     if output_dir:
         os.makedirs(output_dir, exist_ok=True)
@@ -24,7 +31,6 @@ def main(output_path):
     wine_df.to_csv(output_path, index=False)
     print(f"Raw data saved to {output_path}")
     print(f"Dataset shape: {wine_df.shape}")
-
 
 if __name__ == "__main__":
     main()

--- a/scripts/download_data.py
+++ b/scripts/download_data.py
@@ -3,6 +3,7 @@ import pandas as pd
 import os
 from ucimlrepo import fetch_ucirepo
 
+
 @click.command()
 @click.option(
     "--output-path",

--- a/scripts/preprocess_data.py
+++ b/scripts/preprocess_data.py
@@ -1,9 +1,10 @@
 import click
 import pandas as pd
 import os
+import numpy as np
+import warnings
 from sklearn.model_selection import train_test_split
 from src.data_utils import extract_features_and_target
-
 
 @click.command()
 @click.option(
@@ -28,6 +29,51 @@ def main(input_path, train_output_path, test_output_path):
     """Split the wine quality dataset into training (70%) and test (30%) sets."""
     wine_df = pd.read_csv(input_path)
 
+    # ------------------------------------------
+    # PRE-SPLIT DATA VALIDATION CHECKS 
+    # ------------------------------------------
+    # Check 2: Correct column names (match expected schema)
+    assert "quality" in wine_df.columns, "Validation Hard Fail: Target column 'quality' is missing."
+    
+    # Check 3: No empty observations (no fully-null rows)
+    assert not wine_df.isnull().all(axis=1).any(), "Validation Hard Fail: Dataset contains completely empty rows."
+    
+    # Check 4: Missingness not beyond expected threshold (< 5% per column)
+    max_missing_pct = wine_df.isnull().mean().max()
+    assert max_missing_pct < 0.05, f"Validation Hard Fail: Missing data exceeds 5% threshold (Max: {max_missing_pct:.1%})"
+    
+    # Check 5: Correct data types in each column (Wine data should be 100% numeric)
+    non_numeric_cols = wine_df.select_dtypes(exclude=[np.number]).columns
+    assert len(non_numeric_cols) == 0, f"Validation Hard Fail: Non-numeric columns detected: {list(non_numeric_cols)}"
+    
+    # Check 6: Correct category levels/Expected range (Quality must be between 0 and 10)
+    assert wine_df["quality"].between(0, 10).all(), "Validation Hard Fail: 'quality' values found outside the expected 0-10 range."
+    
+    # ------------------------------------------
+    # PRE-SPLIT DATA VALIDATION CHECKS (Warnings)
+    # ------------------------------------------
+    # Check 7: No duplicate observations
+    if wine_df.duplicated().any():
+        num_dupes = wine_df.duplicated().sum()
+        warnings.warn(f"Validation Warning: {num_dupes} duplicate observations detected in the dataset.")
+
+    # Check 8: No outlier or anomalous values (Using extreme 3x IQR rule)
+    numeric_features = wine_df.drop(columns=["quality"])
+    q1 = numeric_features.quantile(0.25)
+    q3 = numeric_features.quantile(0.75)
+    iqr = q3 - q1
+    extreme_outliers = ((numeric_features < (q1 - 3 * iqr)) | (numeric_features > (q3 + 3 * iqr)))
+    if extreme_outliers.any().any():
+        warnings.warn("Validation Warning: Extreme outliers (> 3x IQR) detected in feature columns.")
+
+    # Check 9: Target/response variable follows expected distribution 
+    if wine_df["quality"].nunique() < 3:
+        warnings.warn(f"Validation Warning: Target 'quality' distribution is unexpectedly narrow (Only {wine_df['quality'].nunique()} unique values).")
+
+
+    # ------------------------------------------
+    # DATA SPLIT
+    # ------------------------------------------
     X, y = extract_features_and_target(wine_df, "quality")
 
     X_train, X_test, y_train, y_test = train_test_split(
@@ -42,6 +88,25 @@ def main(input_path, train_output_path, test_output_path):
     test_df["quality"] = y_test
     test_df = test_df.reset_index(drop=True)
 
+
+    # ------------------------------------------
+    # POST-SPLIT VALIDATION CHECKS - NO LEAKAGE (Warnings)
+    # ------------------------------------------
+    # Check 10: No anomalous correlations between target and features (training set)
+    target_correlations = train_df.corr()["quality"].drop("quality").abs()
+    if target_correlations.max() > 0.95:
+        warnings.warn(f"Validation Warning: Suspiciously high feature-target correlation detected (Max: {target_correlations.max():.2f}). Check for data leakage.")
+
+    # Check 11: No anomalous correlations between features (training set)
+    feature_corr_matrix = X_train.corr().abs()
+    upper_tri = feature_corr_matrix.where(np.triu(np.ones(feature_corr_matrix.shape), k=1).astype(bool))
+    if upper_tri.max().max() > 0.98:
+        warnings.warn(f"Validation Warning: Highly collinear features detected (Max correlation: {upper_tri.max().max():.2f}).")
+
+
+    # ------------------------------------------
+    # SAVE OUTPUTS
+    # ------------------------------------------
     for path in [train_output_path, test_output_path]:
         output_dir = os.path.dirname(path)
         if output_dir:
@@ -52,7 +117,6 @@ def main(input_path, train_output_path, test_output_path):
 
     print(f"Training data ({X_train.shape[0]} samples) saved to {train_output_path}")
     print(f"Test data ({X_test.shape[0]} samples) saved to {test_output_path}")
-
 
 if __name__ == "__main__":
     main()

--- a/scripts/preprocess_data.py
+++ b/scripts/preprocess_data.py
@@ -6,6 +6,7 @@ import warnings
 from sklearn.model_selection import train_test_split
 from src.data_utils import extract_features_and_target
 
+
 @click.command()
 @click.option(
     "--input-path",


### PR DESCRIPTION
# feat: Implement comprehensive data validation checklist

## Note

To ensure our `make all` command doesn't break over expected statistical anomalies (like natural wine outliers or minor collinearity), I split these checks into **Hard Fails** (using `assert` for structural data integrity) and **Soft Warnings** (using `warnings.warn()` for data quality flags).

## Changes Made
### 1. `scripts/download_data.py`
* **Check 1:** Added assertions to ensure the downloaded payload is a valid, non-empty Pandas DataFrame before saving.

### 2. `scripts/preprocess_data.py`
**Pre-Split (Hard Fails):**
* **Check 2:** Correct column names (ensures `quality` exists).
* **Check 3:** No completely empty observations (fully null rows).
* **Check 4:** Missingness threshold (fails if any column is >5% null).
* **Check 5:** Data types (ensures all feature columns are strictly numeric).
* **Check 6:** Expected range (ensures `quality` is between 0 and 10).

**Pre-Split (Warnings):**
* **Check 7:** Flags exact duplicate observations.
* **Check 8:** Flags extreme outliers (> 3x IQR).
* **Check 9:** Flags unexpectedly narrow target distributions (< 3 unique quality classes).

**Post-Split / Leakage Prevention (Warnings):**
* **Check 10:** Target/Feature correlation (flags if > 0.95).
* **Check 11:** Feature/Feature collinearity (flags if > 0.98).
* *Note: Checks 10 & 11 are run strictly on `X_train` and `y_train` after the split to guarantee zero data leakage into the test set.*

## Testing Status
Unfortunately, I was **unable to test this end-to-end** locally. The `ucimlrepo` server is currently returning a `502 Bad Gateway` error, meaning the `make all` pipeline fails at the initial download step before it even reaches our new validation code. 