### PR TITLE
fix: update docker digest, make test target, remove stale pytest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,9 +45,9 @@ clean:
 	rm -f results/*.png
 	rm -rf _output/
 
-# Run all unit tests
+# Run all unit tests (in the winepredictor package)
 test:
-	python -m pytest tests/
+	python -m pytest --pyargs winepredictor
 
 # Helper to explain the Makefile
 help:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This project investigates whether the quality of wine can be predicted from its 
 2. Pull the image from DockerHub:
 
    ```bash
-   docker pull jacoblum22/dsci-310-group-03@sha256:b88aaf638ca3379d2478c4c27d60a68d6cd50db9e732d1bba63a79c2da124f2d
+   docker pull jacoblum22/dsci-310-group-03@sha256:e69bf54a3686be8cc48fc2544b1f8d6418495aaca68d99dbb88772fdbbd9ec61
    ```
 
 3. Launch the container with Docker Compose:
@@ -101,7 +101,6 @@ The project dependencies are managed via [environment.yml](environment.yml). Key
 | scikit-learn | 1.8.0 |
 | matplotlib | 3.10.8 |
 | seaborn | 0.13.2 |
-| pytest | 9.0.2 |
 | ucimlrepo | 0.0.7 |
 | click | 8.3.1 |
 | tabulate | 0.10.0 |


### PR DESCRIPTION
Pre-release audit fixes:
- Update docker pull digest in README to match docker-compose.yml
- Fix make test to use --pyargs winepredictor (tests/ dir removed in T3)
- Remove stale pytest entry from dependency table (not in environment.yml)